### PR TITLE
Configurable DateTime types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /deps
 erl_crash.dump
 *.ez
+/.elixir_ls

--- a/lib/coherence/config.ex
+++ b/lib/coherence/config.ex
@@ -139,7 +139,8 @@ defmodule Coherence.Config do
     :user_schema,
     :user_token,
     {:verify_user_token, &Coherence.SessionService.verify_user_token/2},
-    :web_module
+    :web_module,
+    {:datetime_module, NaiveDateTime}
   ]
   |> Enum.each(fn
     {key, default} ->

--- a/lib/coherence/controllers/confirmation_controller_base.ex
+++ b/lib/coherence/controllers/confirmation_controller_base.ex
@@ -122,7 +122,7 @@ defmodule Coherence.ConfirmationControllerBase do
                 end
                 |> Map.merge(%{
                   confirmation_token: nil,
-                  confirmed_at: NaiveDateTime.utc_now()
+                  confirmed_at: Config.datetime_module().utc_now()
                 })
 
               changeset = Controller.changeset(:confirmation, user_schema, user, attrs)

--- a/lib/coherence/controllers/controller.ex
+++ b/lib/coherence/controllers/controller.ex
@@ -125,13 +125,11 @@ defmodule Coherence.Controller do
       iex> ~N(2016-10-10 10:10:10)
       ...> |> Coherence.Controller.shift(days: -2)
       ...> |> to_string
-      "2016-10-08 10:10:10Z"
+      "2016-10-08 10:10:10"
   """
   @spec shift(struct, Keyword.t()) :: struct
   def shift(datetime, opts) do
     datetime
-    |> NaiveDateTime.to_erl()
-    |> Timex.to_datetime()
     |> Timex.shift(opts)
   end
 
@@ -174,7 +172,7 @@ defmodule Coherence.Controller do
       token = random_string(48)
       url = router_helpers().confirmation_url(conn, :edit, token)
       Logger.debug("confirmation email url: #{inspect(url)}")
-      dt = NaiveDateTime.utc_now()
+      dt = Config.datetime_module().utc_now()
 
       user
       |> user_schema.changeset(%{
@@ -226,7 +224,7 @@ defmodule Coherence.Controller do
   can set this data far in the future to do a pseudo permanent lock.
   """
   @spec lock!(Ecto.Schema.t(), struct) :: schema_or_error
-  def lock!(user, locked_at \\ NaiveDateTime.utc_now()) do
+  def lock!(user, locked_at \\ Config.datetime_module().utc_now()) do
     user_schema = Config.user_schema()
     changeset = user_schema.lock(user, locked_at)
 

--- a/lib/coherence/controllers/password_controller_base.ex
+++ b/lib/coherence/controllers/password_controller_base.ex
@@ -167,7 +167,7 @@ defmodule Coherence.PasswordControllerBase do
       def recover_password(conn, user_schema, user, params) do
         token = random_string(48)
         url = router_helpers().password_url(conn, :edit, token)
-        dt = NaiveDateTime.utc_now()
+        dt = Config.datetime_module().utc_now()
         info = Messages.backend().reset_email_sent()
 
         Config.repo().update!(

--- a/lib/coherence/controllers/session_controller_base.ex
+++ b/lib/coherence/controllers/session_controller_base.ex
@@ -286,7 +286,7 @@ defmodule Coherence.SessionControllerBase do
                 |> track_lock(user, user.__struct__.trackable_table?())
 
               {put_flash(new_conn, :error, Messages.backend().maximum_login_attempts_exceeded()),
-               %{locked_at: NaiveDateTime.utc_now()}}
+               %{locked_at: Config.datetime_module().utc_now()}}
 
             true ->
               {put_flash(

--- a/lib/coherence/schema.ex
+++ b/lib/coherence/schema.ex
@@ -254,7 +254,8 @@ defmodule Coherence.Schema do
 
         Returns a changeset ready for Repo.update
         """
-        def lock(user, locked_at \\ NaiveDateTime.utc_now()) do
+        def lock(user, locked_at \\ nil) do
+          locked_at = locked_at || Config.datetime_module().utc_now()
           Config.user_schema().changeset(user, %{locked_at: locked_at})
         end
 
@@ -270,7 +271,8 @@ defmodule Coherence.Schema do
         deprecated! Please use Coherence.ControllerHelpers.lock!/1.
         """
 
-        def lock!(user, locked_at \\ NaiveDateTime.utc_now()) do
+        def lock!(user, locked_at \\ nil) do
+          locked_at = locked_at || Config.datetime_module().utc_now()
           IO.warn(
             "#{inspect(Config.user_schema())}.lock!/1 has been deprecated. Please use Coherence.ControllerHelpers.lock!/1 instead."
           )
@@ -419,7 +421,8 @@ defmodule Coherence.Schema do
         end
 
   """
-  defmacro coherence_schema do
+  defmacro coherence_schema(opts \\ []) do
+    datetime_type = Keyword.get(opts, :datetime, :naive_datetime)
     quote do
       if Coherence.Config.has_option(:authenticatable) do
         field(Config.password_hash(), :string)
@@ -434,17 +437,17 @@ defmodule Coherence.Schema do
 
       if Coherence.Config.has_option(:recoverable) do
         field(:reset_password_token, :string)
-        field(:reset_password_sent_at, :naive_datetime)
+        field(:reset_password_sent_at, unquote(datetime_type))
       end
 
       if Coherence.Config.has_option(:rememberable) do
-        field(:remember_created_at, :naive_datetime)
+        field(:remember_created_at, unquote(datetime_type))
       end
 
       if Coherence.Config.has_option(:trackable) do
         field(:sign_in_count, :integer, default: 0)
-        field(:current_sign_in_at, :naive_datetime)
-        field(:last_sign_in_at, :naive_datetime)
+        field(:current_sign_in_at, unquote(datetime_type))
+        field(:last_sign_in_at, unquote(datetime_type))
         field(:current_sign_in_ip, :string)
         field(:last_sign_in_ip, :string)
       end
@@ -455,7 +458,7 @@ defmodule Coherence.Schema do
 
       if Coherence.Config.has_option(:lockable) do
         field(:failed_attempts, :integer, default: 0)
-        field(:locked_at, :naive_datetime)
+        field(:locked_at, unquote(datetime_type))
       end
 
       if Coherence.Config.has_option(:unlockable_with_token) do
@@ -464,8 +467,8 @@ defmodule Coherence.Schema do
 
       if Coherence.Config.has_option(:confirmable) do
         field(:confirmation_token, :string)
-        field(:confirmed_at, :naive_datetime)
-        field(:confirmation_sent_at, :naive_datetime)
+        field(:confirmed_at, unquote(datetime_type))
+        field(:confirmation_sent_at, unquote(datetime_type))
 
         if Coherence.Config.get(:confirm_email_updates) do
           field(:unconfirmed_email, :string)

--- a/lib/coherence/services/confirmable_service.ex
+++ b/lib/coherence/services/confirmable_service.ex
@@ -61,7 +61,7 @@ defmodule Coherence.ConfirmableService do
         """
         def confirm(user) do
           Schemas.change_user(user, %{
-            confirmed_at: NaiveDateTime.utc_now(),
+            confirmed_at: Config.datetime_module().utc_now(),
             confirmation_token: nil
           })
         end
@@ -80,7 +80,7 @@ defmodule Coherence.ConfirmableService do
 
           changeset =
             Schemas.change_user(user, %{
-              confirmed_at: NaiveDateTime.utc_now(),
+              confirmed_at: Config.datetime_module().utc_now(),
               confirmation_token: nil
             })
 
@@ -114,7 +114,7 @@ defmodule Coherence.ConfirmableService do
   """
   @spec confirm(Ecto.Schema.t()) :: Ecto.Changeset.t()
   def confirm(user) do
-    Schemas.change_user(user, %{confirmed_at: NaiveDateTime.utc_now(), confirmation_token: nil})
+    Schemas.change_user(user, %{confirmed_at: Config.datetime_module().utc_now(), confirmation_token: nil})
   end
 
   @doc """
@@ -127,7 +127,7 @@ defmodule Coherence.ConfirmableService do
   @spec confirm!(Ecto.Schema.t()) :: Ecto.Changeset.t() | {:error, Ecto.Changeset.t()}
   def confirm!(user) do
     changeset =
-      Schemas.change_user(user, %{confirmed_at: NaiveDateTime.utc_now(), confirmation_token: nil})
+      Schemas.change_user(user, %{confirmed_at: Config.datetime_module().utc_now(), confirmation_token: nil})
 
     if confirmed?(user) do
       changeset =

--- a/lib/coherence/services/password_service.ex
+++ b/lib/coherence/services/password_service.ex
@@ -29,7 +29,7 @@ defmodule Coherence.PasswordService do
   """
   def reset_password_token(user) do
     token = Controller.random_string(48)
-    dt = NaiveDateTime.utc_now()
+    dt = Config.datetime_module().utc_now()
 
     :password
     |> Controller.changeset(user.__struct__, user, %{

--- a/lib/coherence/services/trackable_service.ex
+++ b/lib/coherence/services/trackable_service.ex
@@ -71,7 +71,7 @@ defmodule Coherence.TrackableService do
     changeset =
       Controller.changeset(:session, user.__struct__, user, %{
         sign_in_count: user.sign_in_count + 1,
-        current_sign_in_at: NaiveDateTime.utc_now(),
+        current_sign_in_at: Config.datetime_module().utc_now(),
         current_sign_in_ip: ip,
         last_sign_in_at: last_at,
         last_sign_in_ip: last_ip
@@ -98,7 +98,7 @@ defmodule Coherence.TrackableService do
       Controller.changeset(:session, schema, schema.__struct__, %{
         action: "login",
         sign_in_count: trackable.sign_in_count + 1,
-        current_sign_in_at: NaiveDateTime.utc_now(),
+        current_sign_in_at: Config.datetime_module().utc_now(),
         current_sign_in_ip: ip,
         last_sign_in_at: last_at,
         last_sign_in_ip: last_ip,
@@ -226,7 +226,7 @@ defmodule Coherence.TrackableService do
   end
 
   defp last_at_and_ip(conn, schema) do
-    now = NaiveDateTime.utc_now()
+    now = Config.datetime_module().utc_now()
     ip = Plug.Conn.get_peer_data(conn) |> Map.get(:address) |> inspect()
 
     cond do


### PR DESCRIPTION
This PR adds the possibility to configure the DateTime module used to generate `utc_now()` datetimes and the types of all datetime fields in the user schema.

`config.exs`

```elixir
config :coherence,  
  datetime_module: DateTime
```

`user.ex`
```elixir
#...
  schema "users" do
    coherence_schema(datetime: :utc_datetime)
  end
```